### PR TITLE
Fix land cover class mixup in palette and legend

### DIFF
--- a/docs/projects/ca_lc.md
+++ b/docs/projects/ca_lc.md
@@ -122,7 +122,7 @@ DOI: https://doi.org/10.1016/j.rse.2022.112780 [Open Access]
 var forest_lc = ee.ImageCollection("projects/sat-io/open-datasets/CA_FOREST_LC_VLCE2");
 ```
 
-Sample code: https://code.earthengine.google.com/54c9f53ea9c44a6f4a3ecbbcdcf57e73
+Sample code: https://code.earthengine.google.com/77c8d6c058c492fb71e0c2d439345952
 
 
 #### License


### PR DESCRIPTION
Firstly - thanks for this incredible resource. 

I was working with the Canadian forestry land cover product from Hermosilla et al 2022. 
https://samapriya.github.io/awesome-gee-community-datasets/projects/ca_lc/

There is a mistake in the example script where two land cover classes (Wetland treed and Herbs) are remapped to the value 8. 

I've included an updated example script, that also prints the remap dict for users so they can more easily check from the remapped 0-12 values to the original land cover class codes.

https://code.earthengine.google.com/77c8d6c058c492fb71e0c2d439345952 

Let me know what you think, thanks!