### PR TITLE
Fix published version of soil carbon storage

### DIFF
--- a/docs/projects/scs.md
+++ b/docs/projects/scs.md
@@ -3,7 +3,12 @@
 This collection contains datasets with the spatial distribution of carbon stock in soil and plants of Canada and canopy heights. It is being made public to act as supplementary data for the publication 'Large soil carbon storage in terrestrial ecosystems of Canada', currently under review.
 The maps were produced in the Remote Sensing Lab, McMaster University, between January and December 2020. This research project was made possible by a grant from the World Wildlife Fund (WWF)- Canada. This project aimed to produce the first wall-to-wall estimate of carbon stocks in plants and soils of Canada at 250 m spatial resolution using multisource satellite, climate and topographic data and a machine-learning algorithm.
 
-You can read the [preprint of the paper here](https://www.essoar.org/doi/10.1002/essoar.10507117.2) and [download the datasets from collection here](https://data.4tu.nl/collections/Carbon_storage_and_distribution_in_terrestrial_ecosystems_of_Canada/5421810)
+You can read the [paper here](https://doi.org/10.1029/2021GB007213) and download the datasets: 
+
+- Spatial distribution of maximum canopy height and heights percentiles (https://doi.org/10.4121/14573079.v1)
+- Forest carbon stock and uncertainty maps (https://doi.org/10.4121/14572929.v1)
+- Soil carbon stock and uncertainty maps (https://doi.org/10.4121/16686154.v3)
+
 
 #### Dataset descriptors
 
@@ -30,8 +35,7 @@ To generate the soil carbon stock map, we used 6,490 ground samples of soil orga
 #### Data Citation
 
 ```
-Sothe, Camile; Gonsamo, Alemu; Arabian, Joyce; Kurz, Werner A.; Finkelstein, Sarah; Snider, James (2021): Soil organic carbon stock and
-uncertainties, 1m depth, at 250m spatial resolution in Canada, version 2.0. 4TU.ResearchData. Dataset. https://doi.org/10.4121/16686154.v1
+Sothe, C., Gonsamo, A., Arabian, J., Kurz, W. A., Finkelstein, S. A., & Snider, J. (2022). Large soil carbon storage in terrestrial ecosystems of Canada. Global Biogeochemical Cycles, 36, e2021GB007213. https://doi.org/10.1029/2021GB007213 
 ```
 
 ![ca_carbon](https://user-images.githubusercontent.com/6677629/141673532-bfd657f7-941a-4687-948e-fab97102908b.gif)
@@ -52,7 +56,7 @@ Sample code: https://code.earthengine.google.com/b17184d3dd1b54434be2a2abd1fc63a
 #### License
 This work is licensed under and freely available to the public (similar to a CC0 license).
 
-Created by: Sothe et al 2021
+Created by: Sothe et al 2022
 
 Curated in GEE by : Samapriya Roy
 

--- a/docs/projects/scs.md
+++ b/docs/projects/scs.md
@@ -6,7 +6,7 @@ The maps were produced in the Remote Sensing Lab, McMaster University, between J
 You can read the [paper here](https://doi.org/10.1029/2021GB007213) and download the datasets: 
 
 - Spatial distribution of maximum canopy height and heights percentiles (https://doi.org/10.4121/14573079.v1)
-- Forest carbon stock and uncertainty maps (https://doi.org/10.4121/14572929.v1)
+- Forest carbon stock and uncertainty maps (https://data.4tu.nl/articles/dataset/Carbon_map_and_uncertainty_in_forested_areas_of_Canada_250m_spatial_resolution/14572929/2)
 - Soil carbon stock and uncertainty maps (https://doi.org/10.4121/16686154.v3)
 
 


### PR DESCRIPTION
Just noticed the awesome gee community page was made while this data was in a pre-print.
"Soil carbon storage in terrestrial ecosystems of Canada": https://samapriya.github.io/awesome-gee-community-datasets/projects/scs/
 
It is now published and I was hoping we could update the data to match the published version?

Tracking down the version numbers and dates:

2021-05-18: [Carbon storage and distribution data collection](https://data.4tu.nl/collections/Carbon_storage_and_distribution_in_terrestrial_ecosystems_of_Canada/5421810/1) released including [Canopy height data](https://data.4tu.nl/articles/dataset/Spatial_distribution_of_maximum_canopy_height_and_heights_percentiles_in_Canada_at_250m_spatial_resolution/14573079),  [Soil organic carbon stock data](https://data.4tu.nl/articles/dataset/Soil_organic_carbon_stock_and_uncertainties_1m_depth_at_250m_spatial_resolution_in_Canada/14573526?backTo=/collections/Carbon_storage_and_distribution_in_terrestrial_ecosystems_of_Canada/5421810), and [Carbon stock map and uncertainty data](https://data.4tu.nl/articles/dataset/Carbon_map_and_uncertainty_in_forested_areas_of_Canada_250m_spatial_resolution/14572929/1)

2021-09-15: [Carbon storage and distribution data collection](https://data.4tu.nl/collections/Carbon_storage_and_distribution_in_terrestrial_ecosystems_of_Canada/5421810/2) updated

2021-09-28: [Pre-print](https://www.essoar.org/doi/10.1002/essoar.10507117.2) released and [Carbon storage and distribution data collection](https://data.4tu.nl/collections/Carbon_storage_and_distribution_in_terrestrial_ecosystems_of_Canada/5421810/3) updated

2021-11-14: **Last update on GEE**

2021-12-29: [Soil organic carbon stock data](https://data.4tu.nl/articles/dataset/Soil_organic_carbon_stock_and_uncertainties_1m_depth_at_250m_spatial_resolution_in_Canada_version_2_0/16686154/1) updated

2022-01-05: [Soil organic carbon stock data](https://data.4tu.nl/articles/dataset/Soil_organic_carbon_stock_and_uncertainties_1m_depth_at_250m_spatial_resolution_in_Canada_version_2_0/16686154/3) updated

2022-02-02: [Paper published](https://agupubs.onlinelibrary.wiley.com/doi/full/10.1029/2021GB007213)

2022-02-04: [Carbon stock map and uncertainty data](https://data.4tu.nl/articles/dataset/Carbon_map_and_uncertainty_in_forested_areas_of_Canada_250m_spatial_resolution/14572929/2) updated

I'm not related to the group that generated the data so I am not clear on all the details. Just parsing what I can from the preprint, publication and open data pages. 

From the publication and above timeline, the most recent versions of the data therefore are:

- 2021-05-18: Spatial distribution of maximum canopy height and heights percentiles (https://doi.org/10.4121/14573079.v1)
- 2022-04-02: Forest carbon stock and uncertainty maps (https://data.4tu.nl/articles/dataset/Carbon_map_and_uncertainty_in_forested_areas_of_Canada_250m_spatial_resolution/14572929/2)
- 2022-01-05: Soil carbon stock and uncertainty maps (https://doi.org/10.4121/16686154.v3)

I think this means that the canopy height data is fine, but the soil carbon and forest carbon datasets are out of date with respect to the publication. Let me know what you think, thank you!

